### PR TITLE
[84] Provide basic integration tests

### DIFF
--- a/hamster_cli/config.ini
+++ b/hamster_cli/config.ini
@@ -1,8 +1,8 @@
 [Backend]
-work_dir: .
+work_dir: ./.hamster_cli
 store: sqlalchemy
 daystart: 00:00:00
-db_path: postgres://hamsterlib:foobar@localhost/hamsterlib
+db_path: sqlite:///./.hamster_cli/hamster_cli.db
 tmpfile_name: hamster_cli.tmp
 fact_min_delta: 60
 

--- a/hamster_cli/config.ini
+++ b/hamster_cli/config.ini
@@ -1,8 +1,9 @@
 [Backend]
-work_dir: tmp
+work_dir: .
 store: sqlalchemy
 daystart: 00:00:00
 db_path: postgres://hamsterlib:foobar@localhost/hamsterlib
+tmpfile_name: hamster_cli.tmp
 fact_min_delta: 60
 
 [Client]

--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -564,3 +564,7 @@ def _generate_facts_table(facts):
         ))
 
     return (table, header)
+
+
+if __name__ == '__main__':
+    run()

--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -105,7 +105,7 @@ def _search(controler, search_term, time_range):
         start, end = helpers.complete_timeframe(helpers.parse_time_range(time_range),
             controler.config)
 
-    results = controler.facts.get_all(search_term=search_term, start=start, end=end)
+    results = controler.facts.get_all(filter_term=search_term, start=start, end=end)
 
     table, headers = _generate_facts_table(results)
     click.echo(tabulate(table, headers=headers))

--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -469,7 +469,7 @@ def _get_config(file_path):
             raise ValueError(_("Unrecognized log level value in config"))
 
         return {
-            'unsorted_localized': config.get('Backend', 'unsorted_localized'),
+            'unsorted_localized': config.get('Client', 'unsorted_localized'),
             'log_console': config.getboolean('Client', 'log_console'),
             'log_file': config.getboolean('Client', 'log_file'),
             'log_filename': config.get('Client', 'log_filename'),
@@ -510,7 +510,7 @@ def _get_config(file_path):
             'store': store,
             'day_start': day_start,
             'db-path': config.get('Backend', 'db_path'),
-            'tmpfile_name': config.get('Client', 'tmpfile_name'),
+            'tmpfile_name': config.get('Backend', 'tmpfile_name'),
             'fact_min_delta': config.get('Backend', 'fact_min_delta'),
         }
 

--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -509,7 +509,7 @@ def _get_config(file_path):
             'work_dir': config.get('Backend', 'work_dir'),
             'store': store,
             'day_start': day_start,
-            'db-path': config.get('Backend', 'db_path'),
+            'db_path': config.get('Backend', 'db_path'),
             'tmpfile_name': config.get('Backend', 'tmpfile_name'),
             'fact_min_delta': config.get('Backend', 'fact_min_delta'),
         }

--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -293,7 +293,7 @@ def _export(controler, format, start, end):
     if format not in accepted_formats:
         message = _("Unrecocgnized export format recieved")
         controler.client_logger.info(message)
-        sys.exit(message)
+        raise click.ClickException(message)
     if not start:
         start = None
     if not end:

--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -469,8 +469,7 @@ def _get_config(file_path):
             raise ValueError(_("Unrecognized log level value in config"))
 
         return {
-            'cwd': config.get('Client', 'cwd'),
-            'tmp_filename': config.get('Client', 'tmp_filename'),
+            'unsorted_localized': config.get('Backend', 'unsorted_localized'),
             'log_console': config.getboolean('Client', 'log_console'),
             'log_file': config.getboolean('Client', 'log_file'),
             'log_filename': config.get('Client', 'log_filename'),
@@ -507,10 +506,11 @@ def _get_config(file_path):
             sys.exit(_("Unrecognized store option."))
 
         return {
-            'day_start': day_start,
-            'unsorted_localized': config.get('Backend', 'unsorted_localized'),
+            'work_dir': config.get('Backend', 'work_dir'),
             'store': store,
+            'day_start': day_start,
             'db-path': config.get('Backend', 'db_path'),
+            'tmpfile_name': config.get('Client', 'tmpfile_name'),
             'fact_min_delta': config.get('Backend', 'fact_min_delta'),
         }
 

--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -62,7 +62,7 @@ pass_controler = click.make_pass_decorator(Controler, ensure=True)
 @pass_controler
 def run(controler):
     """General context provider. Is triggered on all command calls."""
-    _run()
+    _run(controler)
 
 
 def _run(controler):
@@ -85,7 +85,7 @@ def search(controler, search_term, time_range):
         time_range (optional): Only fact within this timerange will be considered.
 
     """
-    _search(search_term, time_range)
+    _search(controler, search_term, time_range)
 
 
 def _search(controler, search_term, time_range):
@@ -126,7 +126,7 @@ def list(controler, time_range):
     Note:
         * This is effectivly just a specical version of `search`
     """
-    _search(time_range=time_range)
+    _search(controler, search_term='', time_range=time_range)
 
 
 @run.command()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,24 +72,23 @@ def config_file(tmpdir, faker):
             config = SafeConfigParser()
 
             config.add_section('Client')
-            config.set('Client', 'cwd', kwargs.get('cwd', '.'))
-            config.set('Client', 'tmp_filename', kwargs.get('tmp_filename',
-                'test_tmp_fact.pickle'))
-            config.set('Client', 'log_level', kwargs.get('log_level', 'debug'))
+            config.set('Client', 'unsorted_localized', kwargs.get(
+                'unsorted_localized', 'Unsorted'))
             config.set('Client', 'log_console', kwargs.get('log_console', '0'))
             config.set('Client', 'log_file', kwargs.get('log_file', '0'))
-            config.set('Client', 'log_filename', kwargs.get('log_filename',
-                faker.file_name()))
+            config.set('Client', 'log_filename', kwargs.get('log_filename', faker.file_name()))
+            config.set('Client', 'log_level', kwargs.get('log_level', 'debug'))
             config.set('Client', 'dbus', kwargs.get('dbus', '0'))
 
             config.add_section('Backend')
-            config.set('Backend', 'unsorted_localized', kwargs.get(
-                'unsorted_localized', 'Unsorted'))
+            config.set('Backend', 'work_dir', kwargs.get('work_dir', '.'))
             config.set('Backend', 'store', kwargs.get('store', 'sqlalchemy'))
             config.set('Backend', 'daystart', kwargs.get('daystart',
                 '00:00:00'))
             config.set('Backend', 'db_path', kwargs.get('db_path',
                 'postgres://hamsterlib:foobar@localhost/hamsterlib'))
+            config.set('Backend', 'tmpfile_name', kwargs.get('file_name',
+                'test_tmp_fact.pickle'))
             config.set('Backend', 'fact_min_delta', kwargs.get('fact_min_delta', '60'))
             config.write(fobj)
         return path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,27 +137,27 @@ def controler_with_logging(lib_config, client_config):
 
 @pytest.fixture(params=[
     ('', '', {
-        'search_term': '',
+        'filter_term': '',
         'start': None,
         'end': None,
     }),
     ('', '2015-12-12 18:00 2015-12-12 19:30', {
-        'search_term': '',
+        'filter_term': '',
         'start': datetime.datetime(2015, 12, 12, 18, 0, 0),
         'end': datetime.datetime(2015, 12, 12, 19, 30, 0)
     }),
     ('', '2015-12-12 18:00', {
-        'search_term': '',
+        'filter_term': '',
         'start': datetime.datetime(2015, 12, 12, 18, 0, 0),
         'end': datetime.datetime(2015, 12, 12, 23, 59, 59)
     }),
     ('', '2015-12-12', {
-        'search_term': '',
+        'filter_term': '',
         'start': datetime.datetime(2015, 12, 12, 0, 0, 0),
         'end': datetime.datetime(2015, 12, 12, 23, 59, 59)
     }),
     ('', '13:00', {
-        'search_term': '',
+        'filter_term': '',
         'start': datetime.datetime(2015, 12, 12, 13, 0, 0),
         'end': datetime.datetime(2015, 12, 12, 23, 59, 59),
     }),

--- a/tests/test_hamster_cli.py
+++ b/tests/test_hamster_cli.py
@@ -244,7 +244,7 @@ class TestLaunchWindow(object):
 class TestGetConfig(object):
     def test_cwd(self, config_file):
         backend, client = hamster_cli._get_config(config_file())
-        assert client['cwd'] == '.'
+        assert backend['work_dir'] == '.'
 
     @pytest.mark.parametrize('log_level', ['debug'])
     def test_log_levels_valid(self, log_level, config_file):

--- a/tests/test_hamster_cli.py
+++ b/tests/test_hamster_cli.py
@@ -118,9 +118,8 @@ class TestExport():
     def test_invalid_format(self, controler_with_logging, format, mocker):
         """Make sure that passing an invalid format exits prematurely."""
         controler = controler_with_logging
-        hamster_cli.sys.exit = mocker.MagicMock()
-        hamster_cli._export(controler, format, None, None)
-        assert hamster_cli.sys.exit.called
+        with pytest.raises(ClickException):
+            hamster_cli._export(controler, format, None, None)
 
     def test_valid_format(self, controler, controler_with_logging, tmpdir, mocker):
         """Make sure that a valid format returns the apropiate writer class."""

--- a/tests/test_integration_tests.py
+++ b/tests/test_integration_tests.py
@@ -1,0 +1,106 @@
+from __future__ import unicode_literals
+
+
+import pytest
+
+
+class TestBasicRun(object):
+    def test_basic_run(self, runner, mocker):
+        """Make sure that invoking the command passes without exception."""
+        result = runner()
+        assert result.exit_code == 0
+
+
+class TestSearch(object):
+    def test_search(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['search', 'foobar'])
+        assert result.exit_code == 0
+
+
+class TestList(object):
+    def test_list(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['list'])
+        assert result.exit_code == 0
+
+
+@pytest.mark.xfail
+class TestStart(object):
+    def test_start(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['start', 'coding', '', ''])
+        assert result.exit_code == 0
+
+
+class TestStop(object):
+    def test_stop(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['stop'])
+        assert 'Error' in result.output
+        assert result.exit_code == 1
+
+
+class TestCancel(object):
+    def test_cancel(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['cancel'])
+        assert 'Error' in result.output
+        assert result.exit_code == 1
+
+
+@pytest.mark.xfail
+class TestExport(object):
+    def test_export(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['export'])
+        assert 'Error' not in result.output
+        assert result.exit_code == 0
+
+
+class TestCategories(object):
+    def test_categories(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['categories'])
+        assert 'Error' not in result.output
+        assert result.exit_code == 0
+
+
+class TestCurrent(object):
+    def test_current(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['current'])
+        assert 'Error' in result.output
+        assert result.exit_code == 1
+
+
+class TestActivities(object):
+    def test_activities(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['activities'])
+        assert 'Error' not in result.output
+        assert result.exit_code == 0
+
+
+class TestOverview(object):
+    def test_overview(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['overview'])
+        assert 'Error' not in result.output
+        assert result.exit_code == -1
+
+
+class TestStatistics(object):
+    def test_statistics(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['statistics'])
+        assert 'Error' not in result.output
+        assert result.exit_code == -1
+
+
+class TestAbout(object):
+    def test_about(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['about'])
+        assert 'Error' not in result.output
+        assert result.exit_code == -1


### PR DESCRIPTION
This PR continues to clean up our config settings as well as it introduces very basic integration tests for our commands.

Whilst they are not realy covering most input/expectation scenarios they can at least provide basic confidence that calling the command works at all and is not raising any unexpected exception right away.

Also:
- Use slightly saner defaults in example `config.ini`.

Closes: #84 #85
