### PR TITLE
[95] Remove obsolete ``requirements_dev`` file.

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,0 @@
-bumpversion==0.5.3
-flake8==2.5.4
-tox==2.3.1
-coverage==4.0.3
-Sphinx==1.4.1
-


### PR DESCRIPTION
For unknown reasons this file was added to the repository. As is it
unneeded it will be removed.

Closes: #95
