### PR TITLE
[81] Fix bumpversion setting about  ``docs/conf.py``.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ tag = True
 
 [bumpversion:file:hamster_cli/__init__.py]
 
-[bumpversion:file:hamster_cli/docs/conf.py]
+[bumpversion:file:docs/conf.py]
 
 
 [coverage:run]


### PR DESCRIPTION
Bumpversion setting to include `docs/conf.py` used wrong path. This
has been fixed.

Closes: #81
