### PR TITLE
[99] Change 'db_path' value for default config.

### DIFF
--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -598,17 +598,22 @@ def _write_config_file(file_path):
     # [FIXME]
     # This may be usefull to turn into a proper command, so users can restore to
     # factory settings easily.
+
+    def get_db_path():
+        filepath = os.path.join(str(AppDirs.user_data_dir), 'hamster_cli.db')
+        return 'sqlite:////{}'.format(filepath)
+
     config = SafeConfigParser()
 
     # Backend
     config.add_section('Backend')
     config.set('Backend', 'store', 'sqlalchemy')
     config.set('Backend', 'daystart', '00:00:00')
-    config.set('Backend', 'db_path', 'postgres://hamsterlib:foobar@localhost/hamsterlib')
+    config.set('Backend', 'db_path', get_db_path())
     config.set('Backend', 'tmpfile_name', 'test_tmp_fact.pickle')
     config.set('Backend', 'fact_min_delta', '60')
-    config.set('Backend', 'db_engine', 'sqlite')
-    config.set('Backend', 'db_uri', 'hamster_cli.db')
+    config.set('Backend', 'db_engine', '')
+    config.set('Backend', 'db_uri', '')
     config.set('Backend', 'db_user', '')
     config.set('Backend', 'db_password', '')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ def appdirs(mocker, tmpdir):
     """Provide mocked version specific user dirs using a tmpdir."""
     hamster_cli.AppDirs = mocker.MagicMock()
     hamster_cli.AppDirs.user_config_dir = tmpdir.mkdir('config').strpath
+    hamster_cli.AppDirs.user_data_dir = tmpdir.mkdir('data').strpath
     return hamster_cli.AppDirs
 
 


### PR DESCRIPTION
We change the former default to a sqlite file under the users default
data dir.

Closes: #99
