### PR TITLE
[84] Provide basic integration tests

### DIFF
--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -545,7 +545,7 @@ def _get_config(config_instance):
             return config.get('Backend', 'tmpfile_name')
 
         def get_fact_min_delta():
-            return config.get('Backend', 'fact_min_delta'),
+            return config.get('Backend', 'fact_min_delta')
 
         def get_work_dir():
             return work_dir or AppDirs.user_data_dir

--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -422,8 +422,8 @@ def _setup_logging(controler):
         lib_logger.addHandler(console_handler)
         client_logger.addHandler(console_handler)
 
-    if controler.client_config['log_filename']:
-        filename = controler.client_config['log_filename']
+    if controler.client_config['logfile_path']:
+        filename = controler.client_config['logfile_path']
         file_handler = logging.FileHandler(filename, encoding='utf-8')
         file_handler.setFormatter(formatter)
         lib_logger.addHandler(file_handler)

--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -11,9 +11,9 @@ from hamsterlib import Fact, HamsterControl, helpers, reports
 from tabulate import tabulate
 
 try:
-    from configparser import SafeConfigParser
+    from configparser import SafeConfigParser, NoOptionError
 except:
-    from ConfigParser import SafeConfigParser
+    from ConfigParser import SafeConfigParser, NoOptionError
 
 
 """
@@ -457,7 +457,7 @@ def _get_config(config_instance):
     # Once we got proper defaults up and running, this should be cleaner.
     try:
         work_dir = config_instance.get('Client', 'work_dir')
-    except KeyError:
+    except NoOptionError:
         work_dir = None
 
     def get_client_config(config):

--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -259,7 +259,14 @@ def _start(controler, raw_fact, start, end):
     # helper instead. If behaviour similar to the legacy hamster-cli is desired,
     # all that seems needed is to change ``day_start`` to '00:00'.
 
-    # The following is needed becauses end may be ``None``.
+    # The following is needed becauses start and end may be ``None``.
+    if not fact.start:
+        start_date = None
+        start_time = None
+    else:
+        start_date = fact.start.date()
+        start_time = fact.start.time()
+
     if not fact.end:
         end_date = None
         end_time = None
@@ -267,8 +274,7 @@ def _start(controler, raw_fact, start, end):
         end_date = fact.end.date()
         end_time = fact.end.time()
 
-    timeframe = helpers.TimeFrame(fact.start.date(), fact.start.time(),
-        end_date, end_time, None)
+    timeframe = helpers.TimeFrame(start_date, start_time, end_date, end_time, None)
     fact.start, fact.end = helpers.complete_timeframe(timeframe, controler.config)
 
     if tmp_fact:

--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -46,7 +46,75 @@ The main tasks of this CLI are twofold:
 """
 
 
-AppDirs = appdirs.AppDirs('hamster_cli')
+class HamsterAppDirs(appdirs.AppDirs):
+    """Custom class that ensure appdirs exist."""
+    def __init__(self, *args, **kwargs):
+        """Add create flag value to instance."""
+        super(HamsterAppDirs, self).__init__(*args, **kwargs)
+        self.create = True
+
+    @property
+    def user_data_dir(self):
+        """Return ``user_data_dir``."""
+        directory = appdirs.user_data_dir(self.appname, self.appauthor,
+                             version=self.version, roaming=self.roaming)
+        if self.create:
+            self._ensure_directory_exists(directory)
+        return directory
+
+    @property
+    def site_data_dir(self):
+        """Return ``site_data_dir``."""
+        directory = appdirs.site_data_dir(self.appname, self.appauthor,
+                             version=self.version, multipath=self.multipath)
+        if self.create:
+            self._ensure_directory_exists(directory)
+        return directory
+
+    @property
+    def user_config_dir(self):
+        """Return ``user_config_dir``."""
+        directory = appdirs.user_config_dir(self.appname, self.appauthor,
+                               version=self.version, roaming=self.roaming)
+        if self.create:
+            self._ensure_directory_exists(directory)
+        return directory
+
+    @property
+    def site_config_dir(self):
+        """Return ``site_config_dir``."""
+        directory = appdirs.site_config_dir(self.appname, self.appauthor,
+                             version=self.version, multipath=self.multipath)
+        if self.create:
+            self._ensure_directory_exists(directory)
+        return directory
+
+    @property
+    def user_cache_dir(self):
+        """Return ``user_cache_dir``."""
+        directory = appdirs.user_cache_dir(self.appname, self.appauthor,
+                              version=self.version)
+        if self.create:
+            self._ensure_directory_exists(directory)
+        return directory
+
+    @property
+    def user_log_dir(self):
+        """Return ``user_log_dir``."""
+        directory = appdirs.user_log_dir(self.appname, self.appauthor,
+                            version=self.version)
+        if self.create:
+            self._ensure_directory_exists(directory)
+        return directory
+
+    def _ensure_directory_exists(self, directory):
+        """Ensure that the passed path exists."""
+        if not os.path.lexists(directory):
+            os.makedirs(directory)
+        return directory
+
+
+AppDirs = HamsterAppDirs('hamster_cli')
 
 
 class Controler(HamsterControl):

--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -542,7 +542,7 @@ def _get_config(config_instance):
             return config.get('Backend', 'db_path')
 
         def get_tmpfile_name():
-            return config.get('Backend', 'tmpfile_name'),
+            return config.get('Backend', 'tmpfile_name')
 
         def get_fact_min_delta():
             return config.get('Backend', 'fact_min_delta'),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,10 +55,9 @@ def appdirs(mocker, tmpdir):
 
 
 @pytest.fixture
-def runner(config_file):
+def runner(appdirs):
     """Used for integrations tests."""
     def runner(args=[]):
-        hamster_cli.CONFIGFILE_PATH = config_file()
         return CliRunner().invoke(hamster_cli.run, args)
     return runner
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def client_config(tmpdir):
         'unsorted_localized': 'Unsorted',
         'log_level': 10,
         'log_console': False,
-        'log_filename': False,
+        'logfile_path': False,
         'dbus': False,
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,11 +36,21 @@ def filepath(tmpdir, filename):
 @pytest.fixture
 def appdirs(mocker, tmpdir):
     """Provide mocked version specific user dirs using a tmpdir."""
+
+    def ensure_directory_exists(directory):
+        if not os.path.lexists(directory):
+            os.makedirs(directory)
+        return directory
+
     hamster_cli.AppDirs = mocker.MagicMock()
-    hamster_cli.AppDirs.user_config_dir = tmpdir.mkdir('config').strpath
-    hamster_cli.AppDirs.user_data_dir = tmpdir.mkdir('data').strpath
-    hamster_cli.AppDirs.user_cache_dir = tmpdir.mkdir('cache').strpath
-    hamster_cli.AppDirs.user_log_dir = tmpdir.mkdir('log').strpath
+    hamster_cli.AppDirs.user_config_dir = ensure_directory_exists(os.path.join(
+        tmpdir.mkdir('config').strpath, 'hamster_cli/'))
+    hamster_cli.AppDirs.user_data_dir = ensure_directory_exists(os.path.join(
+        tmpdir.mkdir('data').strpath, 'hamster_cli/'))
+    hamster_cli.AppDirs.user_cache_dir = ensure_directory_exists(os.path.join(
+        tmpdir.mkdir('cache').strpath, 'hamster_cli/'))
+    hamster_cli.AppDirs.user_log_dir = ensure_directory_exists(os.path.join(
+        tmpdir.mkdir('log').strpath, 'hamster_cli/'))
     return hamster_cli.AppDirs
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,8 @@ def appdirs(mocker, tmpdir):
     hamster_cli.AppDirs = mocker.MagicMock()
     hamster_cli.AppDirs.user_config_dir = tmpdir.mkdir('config').strpath
     hamster_cli.AppDirs.user_data_dir = tmpdir.mkdir('data').strpath
+    hamster_cli.AppDirs.user_cache_dir = tmpdir.mkdir('cache').strpath
+    hamster_cli.AppDirs.user_log_dir = tmpdir.mkdir('log').strpath
     return hamster_cli.AppDirs
 
 

--- a/tests/test_hamster_cli.py
+++ b/tests/test_hamster_cli.py
@@ -320,3 +320,103 @@ class TestWriteConfigFile(object):
         assert os.path.lexists(filepath) is False
         hamster_cli._write_config_file(filepath)
         assert os.path.lexists(filepath)
+
+
+class TestHamsterAppDirs(object):
+    """Make sure that our custom AppDirs works as intended."""
+
+    def test_user_data_dir_returns_directoy(self, tmpdir, mocker):
+        """Make sure method returns directory."""
+        path = tmpdir.strpath
+        mocker.patch('hamster_cli.hamster_cli.appdirs.user_data_dir', return_value=path)
+        appdir = hamster_cli.HamsterAppDirs('hamster_cli')
+        assert appdir.user_data_dir == path
+
+    @pytest.mark.parametrize('create', [True, False])
+    def test_user_data_dir_creates_file(self, tmpdir, mocker, create, faker):
+        """Make sure that path creation depends on ``create`` attribute."""
+        path = os.path.join(tmpdir.strpath, '{}/'.format(faker.word()))
+        mocker.patch('hamster_cli.hamster_cli.appdirs.user_data_dir', return_value=path)
+        appdir = hamster_cli.HamsterAppDirs('hamster_cli')
+        appdir.create = create
+        assert os.path.exists(appdir.user_data_dir) is create
+
+    def test_site_data_dir_returns_directoy(self, tmpdir, mocker):
+        """Make sure method returns directory."""
+        path = tmpdir.strpath
+        mocker.patch('hamster_cli.hamster_cli.appdirs.site_data_dir', return_value=path)
+        appdir = hamster_cli.HamsterAppDirs('hamster_cli')
+        assert appdir.site_data_dir == path
+
+    @pytest.mark.parametrize('create', [True, False])
+    def test_site_data_dir_creates_file(self, tmpdir, mocker, create, faker):
+        """Make sure that path creation depends on ``create`` attribute."""
+        path = os.path.join(tmpdir.strpath, '{}/'.format(faker.word()))
+        mocker.patch('hamster_cli.hamster_cli.appdirs.site_data_dir', return_value=path)
+        appdir = hamster_cli.HamsterAppDirs('hamster_cli')
+        appdir.create = create
+        assert os.path.exists(appdir.site_data_dir) is create
+
+    def test_user_config_dir_returns_directoy(self, tmpdir, mocker):
+        """Make sure method returns directory."""
+        path = tmpdir.strpath
+        mocker.patch('hamster_cli.hamster_cli.appdirs.user_config_dir', return_value=path)
+        appdir = hamster_cli.HamsterAppDirs('hamster_cli')
+        assert appdir.user_config_dir == path
+
+    @pytest.mark.parametrize('create', [True, False])
+    def test_user_config_dir_creates_file(self, tmpdir, mocker, create, faker):
+        """Make sure that path creation depends on ``create`` attribute."""
+        path = os.path.join(tmpdir.strpath, '{}/'.format(faker.word()))
+        mocker.patch('hamster_cli.hamster_cli.appdirs.user_config_dir', return_value=path)
+        appdir = hamster_cli.HamsterAppDirs('hamster_cli')
+        appdir.create = create
+        assert os.path.exists(appdir.user_config_dir) is create
+
+    def test_site_config_dir_returns_directoy(self, tmpdir, mocker):
+        """Make sure method returns directory."""
+        path = tmpdir.strpath
+        mocker.patch('hamster_cli.hamster_cli.appdirs.site_config_dir', return_value=path)
+        appdir = hamster_cli.HamsterAppDirs('hamster_cli')
+        assert appdir.site_config_dir == path
+
+    @pytest.mark.parametrize('create', [True, False])
+    def test_site_config_dir_creates_file(self, tmpdir, mocker, create, faker):
+        """Make sure that path creation depends on ``create`` attribute."""
+        path = os.path.join(tmpdir.strpath, '{}/'.format(faker.word()))
+        mocker.patch('hamster_cli.hamster_cli.appdirs.site_config_dir', return_value=path)
+        appdir = hamster_cli.HamsterAppDirs('hamster_cli')
+        appdir.create = create
+        assert os.path.exists(appdir.site_config_dir) is create
+
+    def test_user_cache_dir_returns_directoy(self, tmpdir, mocker):
+        """Make sure method returns directory."""
+        path = tmpdir.strpath
+        mocker.patch('hamster_cli.hamster_cli.appdirs.user_cache_dir', return_value=path)
+        appdir = hamster_cli.HamsterAppDirs('hamster_cli')
+        assert appdir.user_cache_dir == path
+
+    @pytest.mark.parametrize('create', [True, False])
+    def test_user_cache_dir_creates_file(self, tmpdir, mocker, create, faker):
+        """Make sure that path creation depends on ``create`` attribute."""
+        path = os.path.join(tmpdir.strpath, '{}/'.format(faker.word()))
+        mocker.patch('hamster_cli.hamster_cli.appdirs.user_cache_dir', return_value=path)
+        appdir = hamster_cli.HamsterAppDirs('hamster_cli')
+        appdir.create = create
+        assert os.path.exists(appdir.user_cache_dir) is create
+
+    def test_user_log_dir_returns_directoy(self, tmpdir, mocker):
+        """Make sure method returns directory."""
+        path = tmpdir.strpath
+        mocker.patch('hamster_cli.hamster_cli.appdirs.user_log_dir', return_value=path)
+        appdir = hamster_cli.HamsterAppDirs('hamster_cli')
+        assert appdir.user_log_dir == path
+
+    @pytest.mark.parametrize('create', [True, False])
+    def test_user_log_dir_creates_file(self, tmpdir, mocker, create, faker):
+        """Make sure that path creation depends on ``create`` attribute."""
+        path = os.path.join(tmpdir.strpath, '{}/'.format(faker.word()))
+        mocker.patch('hamster_cli.hamster_cli.appdirs.user_log_dir', return_value=path)
+        appdir = hamster_cli.HamsterAppDirs('hamster_cli')
+        appdir.create = create
+        assert os.path.exists(appdir.user_log_dir) is create

--- a/tests/test_hamster_cli.py
+++ b/tests/test_hamster_cli.py
@@ -225,9 +225,8 @@ class TestSetupLogging():
         assert controler.lib_logger.handlers == []
         assert controler.client_logger.handlers == []
 
-    def test_setup_logging_log_file_True(self, controler):
-        controler.client_config['log_file'] = True
-        controler.client_config['log_filename'] = 'foobar.log'
+    def test_setup_logging_log_file_True(self, controler, appdirs):
+        controler.client_config['logfile_path'] = os.path.join(appdirs.user_log_dir, 'foobar.log')
         hamster_cli._setup_logging(controler)
         assert isinstance(controler.lib_logger.handlers[0],
             logging.FileHandler)

--- a/tests/test_integration_tests.py
+++ b/tests/test_integration_tests.py
@@ -1,0 +1,109 @@
+from __future__ import unicode_literals
+
+
+class TestBasicRun(object):
+    def test_basic_run(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner()
+        assert result.exit_code == 0
+
+
+class TestSearch(object):
+    def test_search(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['search', 'foobar'])
+        assert result.exit_code == 0
+
+
+class TestList(object):
+    def test_list(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['list'])
+        assert result.exit_code == 0
+
+
+class TestStart(object):
+    def test_start(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['start', 'coding', '', ''])
+        assert result.exit_code == 0
+
+
+class TestStop(object):
+    def test_stop(self, runner):
+        """
+        Make sure that invoking the command passes without exception.
+
+        As we don't have a ``ongoing fact`` by default, we expect an expectation to be raised.
+        """
+        result = runner(['stop'])
+        assert result.exit_code == 1
+
+
+class TestCancel(object):
+    def test_cancel(self, runner):
+        """
+        Make sure that invoking the command passes without exception.
+
+        As we don't have a ``ongoing fact`` by default, we expect an expectation to be raised.
+        """
+        result = runner(['cancel'])
+        assert result.exit_code == 1
+
+
+class TestCurrent(object):
+    def test_current(self, runner):
+        """
+        Make sure that invoking the command passes without exception.
+
+        As we don't have a ``ongoing fact`` by default, we expect an expectation to be raised.
+        """
+        result = runner(['current'])
+        assert result.exit_code == 1
+
+
+class TestExport(object):
+    def test_export(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['export'])
+        assert result.exit_code == 0
+
+
+class TestCategories(object):
+    def test_categories(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['categories'])
+        assert 'Error' not in result.output
+        assert result.exit_code == 0
+
+
+class TestActivities(object):
+    def test_activities(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['activities'])
+        assert 'Error' not in result.output
+        assert result.exit_code == 0
+
+
+class TestOverview(object):
+    def test_overview(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['overview'])
+        assert 'Error' not in result.output
+        assert result.exit_code == -1
+
+
+class TestStatistics(object):
+    def test_statistics(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['statistics'])
+        assert 'Error' not in result.output
+        assert result.exit_code == -1
+
+
+class TestAbout(object):
+    def test_about(self, runner):
+        """Make sure that invoking the command passes without exception."""
+        result = runner(['about'])
+        assert 'Error' not in result.output
+        assert result.exit_code == -1


### PR DESCRIPTION
This PR provides a first batch of very basic integration tests. Their main purpose is to make sure each command is returns without error if called.

Also:
- We introduce a new custom AppDirs subclass that ensures paths returned by `AppDir` acutally exist.
- We fixed several broken config keys.

Closes: #84  #101
