### PR TITLE
[115] Show gpl on startup

### DIFF
--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -489,6 +489,26 @@ def about():
     _launch_window('about')
 
 
+@run.command()
+def license():
+    """Show license information"""
+    license = """
+        'hamster_cli' is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+
+        'hamster_cli' is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with .  If not, see <http://www.gnu.org/licenses/>.
+        """
+    click.echo(license)
+
+
 # Helper functions
 def _setup_logging(controler):
     """Setup logging for the lib_logger as well as client specific logging."""

--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -816,7 +816,7 @@ def _show_greeting():
     click.echo(_("Welcome to 'hamster_cli', your friendly time tracker for the command line."))
     click.echo("Copyright (C) 2015-2016, Eric Goller <elbenfreund@DenkenInEchtzeit.net>")
     click.echo(_(
-        "'hamster_cli' is published under the term of the GPL3, for details please use"
+        "'hamster_cli' is published under the terms of the GPL3, for details please use"
         "the 'license' command."
     ))
     click.echo()

--- a/hamster_cli/hamster_cli.py
+++ b/hamster_cli/hamster_cli.py
@@ -792,5 +792,16 @@ def _generate_facts_table(facts):
     return (table, header)
 
 
+def _show_greeting():
+    click.echo(_("Welcome to 'hamster_cli', your friendly time tracker for the command line."))
+    click.echo("Copyright (C) 2015-2016, Eric Goller <elbenfreund@DenkenInEchtzeit.net>")
+    click.echo(_(
+        "'hamster_cli' is published under the term of the GPL3, for details please use"
+        "the 'license' command."
+    ))
+    click.echo()
+
 if __name__ == '__main__':
+    click.clear()
+    _show_greeting()
     run()

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,10 @@ branch = True
 source = hamster_cli
 omit = hamster_cli/cli_client.py
 
+[coverage:report]
+exclude_lines = 
+	if __name__ == .__main__.:
+
 [isort]
 not_skip = __init__.py
 known_third_party = appdirs, click, faker, factory, fauxfactory, freezegun, future, hamsterlib, past, pytest,

--- a/tests/test_hamster_cli.py
+++ b/tests/test_hamster_cli.py
@@ -435,3 +435,26 @@ class TestHamsterAppDirs(object):
         appdir = hamster_cli.HamsterAppDirs('hamster_cli')
         appdir.create = create
         assert os.path.exists(appdir.user_log_dir) is create
+
+
+class TestShowGreeting(object):
+    """Make shure our greeting function behaves as expected."""
+
+    def test_shows_welcome(self, capsys):
+        """Make sure we welcome our users properly."""
+        hamster_cli._show_greeting()
+        out, err = capsys.readouterr()
+        assert "Welcome to 'hamster_cli'" in out
+
+    def test_shows_copyright(self, capsys):
+        """Make sure we show basic copyright information."""
+        hamster_cli._show_greeting()
+        out, err = capsys.readouterr()
+        assert "Copyright" in out
+
+    def test_shows_license(self, capsys):
+        """Make sure we display a brief reference to the license."""
+        hamster_cli._show_greeting()
+        out, err = capsys.readouterr()
+        assert "GPL3" in out
+        assert "'license' command" in out

--- a/tests/test_integration_tests.py
+++ b/tests/test_integration_tests.py
@@ -107,3 +107,19 @@ class TestAbout(object):
         result = runner(['about'])
         assert 'Error' not in result.output
         assert result.exit_code == -1
+
+
+class TestLicense(object):
+    """Make sure command works as expected."""
+
+    def test_license(self, runner):
+        """Make sure command launches without exception."""
+        result = runner(['license'])
+        assert result.exit_code == 0
+
+    def test_license_is_shown(self, runner):
+        """Make sure the license text is actually displayed."""
+        result = runner(['license'])
+        assert "'hamster_cli' is free software" in result.output
+        assert "GNU General Public License" in result.output
+        assert "version 3" in result.output


### PR DESCRIPTION
This PR opts against bothering our enduser with the full GPL3 blob at every invocation.
Instead we provide some general basic copyright related data and a reference to the new 'license' command. If called, this command will print the desired GPL3 boilerplate.

Closes: #115
