### PR TITLE
[109] Add information about compatibility breaking changes

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,6 +2,22 @@
 Usage
 ========
 
-To use hamster_cli in a project::
+To use hamster_cli simply imvoke it::
 
-    import hamster_cli
+    hamster-cli
+
+Incompabilities
+---------------
+
+We tries hard to stay compatible with *legacy hamster-cli* but there are some aspects where we
+could not do so without make to huge tradeoffs to what we feel is the proper way to do so.
+For transparency and you to evaluate if those breaking points affect you we list them here:
+
+* Only one *ongoing fact* at a time. You will not be able to start more than one fact without
+  providing an endtime. If you do you will be presented with an error and either have to cancel or
+  stop the current *ongoing fact*.
+* Argument values that contain whitespaces need to be wrapped in quoteation marks. This is
+  established practice and needed to stay POSIX compatible. In particular this affects:
+  * start/end - datetimes; As date and time aspects are seperatetd by a whitespace.
+  * ``raw_fact`` arguments; As they contain various whitespaces.
+  * search terms


### PR DESCRIPTION
Whilst our way to handle whitespaces in parameter values breaks with the
legacy hamster API we opt to do so nonetheless in order to stay POSIX
compatible, follow stablished best practices and stick with `Click`
default behaviour.

Closes #109
