### PR TITLE
[#138] linkchecker for docs testsuite

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -97,8 +97,8 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.3, and 3.4, and for PyPy. Check
-   https://travis-ci.org/elbenfreund/hamster_cli/pull_requests
+3. The pull request should work for Python 2.6, 2.7, 3.3, and 3.4, and for
+   PyPy. Check https://travis-ci.org/elbenfreund/hamster_cli/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
 Tips
@@ -109,7 +109,7 @@ To run a subset of tests::
     $ make test TEST_ARGS="-k NAME_OF_TEST_OR_SUB_MODULE"
 
 or if you just want to run a particular tox environment::
-    
+
     $ tox -e NAMEOVENVORONMENT
 
 If you want to play around with an executeable version of you modified client::
@@ -119,6 +119,6 @@ If you want to play around with an executeable version of you modified client::
     $ pip install -e .
 
 This will install your WIP hamster-cli in a wroking state into your sandbox.
-Any changes to the codebase will be applied by that version right away. Please not
-that any files created by the client will persist even if you uninstall it or delete
-the virtualenv.
+Any changes to the codebase will be applied by that version right away. Please
+not that any files created by the client will persist even if you uninstall it
+or delete the virtualenv.

--- a/README.rst
+++ b/README.rst
@@ -27,18 +27,19 @@ hamster_cli
 
 A basic CLI for the hamster time tracker.
 
-*WARGING* 
-This is still pre-alpha software. Altough we are reaching apoint were most things work
-as intended we make no promisse about your data as well as any commitment. In particular there is no
-intension to migrate any databases from this version to any future more mature release.
+*WARNING*
+This is still pre-alpha software. Altough we are reaching apoint were most
+things work as intended we make no promisse about your data as well as any
+commitment. In particular there is no intension to migrate any databases from
+this version to any future more mature release.
 
 News (2016-04-16)
 -----------------
-Version 0.11.0 has been release. This is a major step forward as our previous release was rushed and
-turned out to be not too usable at all. This release Privides a solid and robust way to handle user
-configs as well as providing a default config setup.
-We further increased our test coverage and are well above 90% by now. Including some basic integration
-tests.
+Version 0.11.0 has been release. This is a major step forward as our previous
+release was rushed and turned out to be not too usable at all. This release
+provides a solid and robust way to handle user configs as well as providing a
+default config setup. We further increased our test coverage and are well above
+90% by now. Including some basic integration tests.
 For more details, see the changelog.
 
 Have fun tinkering, Eric.

--- a/docs/notes.rst
+++ b/docs/notes.rst
@@ -7,17 +7,17 @@ that command. This has the added benefit of a clear seperation of unit and
 integration tests.
 
 * For information about unicode handling, see:
-  http://click.pocoo.org/5/python3/#python3-surrogates This should be alright for
-  our usecase, as any properly user environment should have its unicode locale declared.
-  And if not, its acceptable to bully the user to do so.
+  http://click.pocoo.org/5/python3/#python3-surrogates This should be alright
+  for our usecase, as any properly user environment should have its unicode
+  locale declared. And if not, its acceptable to bully the user to do so.
 
 * Click commands deal only with strings. So quite often, the first thing our
   custom command-functions will do is provide some basic type conversion and
   error checking. before calling the corresponding lib method.
 * Whilst the backend usualy either returns results or Errors, the client should
-  always try to handle those errors which are predictable and turn them into user
-  relevant command line output. Only actual errors that are not part of the expected
-  user interaction shall get through as exceptions.
+  always try to handle those errors which are predictable and turn them into
+  user relevant command line output. Only actual errors that are not part of
+  the expected user interaction shall get through as exceptions.
 
 Propably better as subcommands:
 * ``categories`` (list)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -9,15 +9,18 @@ To use hamster_cli simply imvoke it::
 Incompabilities
 ---------------
 
-We tries hard to stay compatible with *legacy hamster-cli* but there are some aspects where we
-could not do so without make to huge tradeoffs to what we feel is the proper way to do so.
-For transparency and you to evaluate if those breaking points affect you we list them here:
+We tries hard to stay compatible with *legacy hamster-cli* but there are some
+aspects where we could not do so without make to huge tradeoffs to what we feel
+is the proper way to do so. For transparency and you to evaluate if those
+breaking points affect you we list them here:
 
-* Only one *ongoing fact* at a time. You will not be able to start more than one fact without
-  providing an endtime. If you do you will be presented with an error and either have to cancel or
-  stop the current *ongoing fact*.
-* Argument values that contain whitespaces need to be wrapped in quoteation marks. This is
-  established practice and needed to stay POSIX compatible. In particular this affects:
-  * start/end - datetimes; As date and time aspects are seperatetd by a whitespace.
+* Only one *ongoing fact* at a time. You will not be able to start more than
+  one fact without providing an endtime. If you do you will be presented with
+  an error and either have to cancel or stop the current *ongoing fact*.
+* Argument values that contain whitespaces need to be wrapped in quoteation
+  marks. This is established practice and needed to stay POSIX compatible. In
+  particular this affects:
+  * start/end - datetimes; As date and time aspects are seperatetd by a
+  whitespace.
   * ``raw_fact`` arguments; As they contain various whitespaces.
   * search terms

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,9 @@ envlist = py27, py34, flake8, isort, pep257, docs, manifest
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/hamster_cli
 whitelist_externals = make
+passenv =
+    SPHINXOPTS_BUILD
+    SPHINXOPTS_LINKCHECK
 commands = 
 	pip install -r requirements/dev.txt
 	make coverage
@@ -46,4 +49,6 @@ basepython = python3.4
 deps = doc8==0.7.0
 commands =
     pip install -r requirements/docs.txt
-    make docs BUILDDIR={envtmpdir} SPHINXOPTS=''
+    make docs BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_BUILD:''}
+    make --directory=docs linkcheck BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_LINKCHECK:}
+    doc8


### PR DESCRIPTION
This PR adds a linkchecker as well as `doc8` to our testsuite.
Several issues have been found and fixed as a consequence.

Closes #138
