### PR TITLE
[#172] Switch from 'hamsterlib' to 'hamster-lib'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ hamster_cli
 .. image:: https://img.shields.io/travis/elbenfreund/hamster_cli/master.svg
         :target: https://travis-ci.org/elbenfreund/hamster_cli
 
-.. image:: https://img.shields.io/codecov/c/github/elbenfreund/hamster_cli/master.svg
-        :target: https://codecov.io/github/elbenfreund/hamster_cli
+.. image:: https://img.shields.io/codecov/c/gh/projecthamster/hamster_cli/master.svg
+        :target: https://codecov.io/gh/projecthamster/hamster-cli
 
 .. image:: https://readthedocs.org/projects/hamst-cli/badge/?version=master
         :target: https://readthedocs.org/projects/hamst-cli/badge/?version=master

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.0
+current_version = 0.11.1
 commit = True
 tag = True
 
@@ -21,7 +21,7 @@ exclude_lines =
 [isort]
 not_skip = __init__.py
 known_third_party = appdirs, backports, click, faker, factory, fauxfactory, freezegun, future,
-	hamsterlib, past, pytest, pytest_factoryboy, six, tabulate
+	hamster_lib, past, pytest, pytest_factoryboy, six, tabulate
 
 [pytest]
 addopt = 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'appdirs',
     'Click',
-    'hamsterlib >= 0.1.0',
+    'hamster-lib',
     'tabulate',
     # py27 compatibility related
     'six',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ import os
 import pickle as pickle
 
 import fauxfactory
-import hamsterlib
+import hamster_lib
 import pytest
 # Once we drop py2 support, we can use the builtin again but unicode support
 # under python 2 is practicly non existing and manual encoding is not easily
@@ -214,7 +214,7 @@ def invalid_tmp_fact(tmpdir, client_config):
 @pytest.yield_fixture
 def controler(lib_config, client_config):
     """Provide a pseudo controler instance."""
-    controler = hamsterlib.HamsterControl(lib_config)
+    controler = hamster_lib.HamsterControl(lib_config)
     controler.client_config = client_config
     yield controler
     controler.store.cleanup()
@@ -223,7 +223,7 @@ def controler(lib_config, client_config):
 @pytest.yield_fixture
 def controler_with_logging(lib_config, client_config):
     """Provide a pseudo controler instance with logging setup."""
-    controler = hamsterlib.HamsterControl(lib_config)
+    controler = hamster_lib.HamsterControl(lib_config)
     controler.client_config = client_config
     # [FIXME]
     # We souldn't shortcut like this!
@@ -238,7 +238,7 @@ def controler_with_logging(lib_config, client_config):
         'start': None,
         'end': None,
     }),
-    ('', '2015-12-12 18:00 2015-12-12 19:30', {
+    ('', '2015-12-12 18:00 - 2015-12-12 19:30', {
         'filter_term': '',
         'start': datetime.datetime(2015, 12, 12, 18, 0, 0),
         'end': datetime.datetime(2015, 12, 12, 19, 30, 0)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -4,21 +4,21 @@ import datetime
 
 import factory
 import faker
-import hamsterlib
+import hamster_lib
 
 
 class CategoryFactory(factory.Factory):
-    """Provide a factory for randomized ``hamsterlib.Category`` instances."""
+    """Provide a factory for randomized ``hamster_lib.Category`` instances."""
 
     pk = None
     name = factory.Faker('word')
 
     class Meta:
-        model = hamsterlib.Category
+        model = hamster_lib.Category
 
 
 class ActivityFactory(factory.Factory):
-    """Provide a factory for randomized ``hamsterlib.Activity`` instances."""
+    """Provide a factory for randomized ``hamster_lib.Activity`` instances."""
 
     pk = None
     name = factory.Faker('word')
@@ -26,11 +26,11 @@ class ActivityFactory(factory.Factory):
     deleted = False
 
     class Meta:
-        model = hamsterlib.Activity
+        model = hamster_lib.Activity
 
 
 class FactFactory(factory.Factory):
-    """Provide a factory for randomized ``hamsterlib.Fact`` instances."""
+    """Provide a factory for randomized ``hamster_lib.Fact`` instances."""
 
     pk = None
     activity = factory.SubFactory(ActivityFactory)
@@ -39,4 +39,4 @@ class FactFactory(factory.Factory):
     description = factory.Faker('paragraph')
 
     class Meta:
-        model = hamsterlib.Fact
+        model = hamster_lib.Fact

--- a/tests/test_hamster_cli.py
+++ b/tests/test_hamster_cli.py
@@ -5,7 +5,7 @@ import logging
 import os
 
 import fauxfactory
-import hamsterlib
+import hamster_lib
 import pytest
 # Once we drop py2 support, we can use the builtin again but unicode support
 # under python 2 is practicly non existing and manual encoding is not easily
@@ -32,6 +32,7 @@ class TestSearch(object):
 class TestStart(object):
     """Unit test related to starting a new fact."""
 
+    @freeze_time('2015-12-25 18:00')
     @pytest.mark.parametrize(('raw_fact', 'start', 'end', 'expectation'), [
         ('foo@bar', '2015-12-12 13:00', '2015-12-12 16:30', {
             'activity': 'foo',
@@ -39,7 +40,7 @@ class TestStart(object):
             'start': datetime.datetime(2015, 12, 12, 13, 0, 0),
             'end': datetime.datetime(2015, 12, 12, 16, 30, 0),
         }),
-        ('10:00-18:00 foo@bar', '2015-12-12 13:00', '', {
+        ('10:00 - 18:00 foo@bar', '2015-12-12 13:00', '', {
             'activity': 'foo',
             'category': 'bar',
             'start': datetime.datetime(2015, 12, 12, 13, 0, 0),
@@ -59,7 +60,6 @@ class TestStart(object):
             'end': None,
         }),
     ])
-    @freeze_time('2015-12-25 18:00')
     def test_start_add_new_fact(self, controler_with_logging, mocker, raw_fact,
             start, end, expectation):
         """
@@ -127,28 +127,29 @@ class TestExport(object):
 
     def test_csv(self, controler, controler_with_logging, mocker):
         """Make sure that a valid format returns the apropiate writer class."""
-        hamsterlib.reports.TSVWriter = mocker.MagicMock()
+        hamster_lib.reports.TSVWriter = mocker.MagicMock()
         hamster_cli._export(controler, 'csv', None, None)
-        assert hamsterlib.reports.TSVWriter.called
+        assert hamster_lib.reports.TSVWriter.called
 
     def test_ical(self, controler, controler_with_logging, mocker):
         """Make sure that a valid format returns the apropiate writer class."""
-        hamsterlib.reports.ICALWriter = mocker.MagicMock()
+        hamster_lib.reports.ICALWriter = mocker.MagicMock()
         hamster_cli._export(controler, 'ical', None, None)
-        assert hamsterlib.reports.ICALWriter.called
+        assert hamster_lib.reports.ICALWriter.called
 
     def test_xml(self, controler, controler_with_logging, mocker):
         """Make sure that passing 'xml' as format parameter returns the apropiate writer class."""
-        hamsterlib.reports.XMLWriter = mocker.MagicMock()
+        hamster_lib.reports.XMLWriter = mocker.MagicMock()
         hamster_cli._export(controler, 'xml', None, None)
-        assert hamsterlib.reports.XMLWriter.called
+        assert hamster_lib.reports.XMLWriter.called
 
     def test_with_start(self, controler, controler_with_logging, tmpdir, mocker):
         """Make sure that passing a end date is passed to the fact gathering method."""
         controler.facts.get_all = mocker.MagicMock()
         path = os.path.join(tmpdir.mkdir('report').strpath, 'report.csv')
-        hamsterlib.reports.TSVWriter = mocker.MagicMock(return_value=hamsterlib.reports.TSVWriter(
-            path))
+        hamster_lib.reports.TSVWriter = mocker.MagicMock(
+            return_value=hamster_lib.reports.TSVWriter(path)
+        )
         start = fauxfactory.gen_datetime()
         hamster_cli._export(controler, 'csv', start, None)
         args, kwargs = controler.facts.get_all.call_args
@@ -158,8 +159,9 @@ class TestExport(object):
         """Make sure that passing a end date is passed to the fact gathering method."""
         controler.facts.get_all = mocker.MagicMock()
         path = os.path.join(tmpdir.mkdir('report').strpath, 'report.csv')
-        hamsterlib.reports.TSVWriter = mocker.MagicMock(return_value=hamsterlib.reports.TSVWriter(
-            path))
+        hamster_lib.reports.TSVWriter = mocker.MagicMock(
+            return_value=hamster_lib.reports.TSVWriter(path)
+        )
         end = fauxfactory.gen_datetime()
         hamster_cli._export(controler, 'csv', None, end)
         args, kwargs = controler.facts.get_all.call_args


### PR DESCRIPTION
As our core lib has changed slightly we now depend on ``hamster-lib`` for most of the heavy lifting.

Closes: #172 
